### PR TITLE
Enable upgrade test to reach level 3+ ?

### DIFF
--- a/check_process
+++ b/check_process
@@ -1,8 +1,3 @@
-# See here for more information
-# https://github.com/YunoHost/package_check#syntax-of-check_process
-
-# Move this file from check_process.default to check_process when you have filled it.
-
 ;; Test complet
 	; Manifest
 		domain="domain.tld"	(DOMAIN)
@@ -19,12 +14,9 @@
 		setup_nourl=0
 		setup_private=1
 		setup_public=1
-		upgrade=0
+		upgrade=1
 		upgrade=0	from_commit=61a8347e52d061269e83a0db50b21cd66039f453
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
 		change_url=1
-;;; Options
-Email=
-Notification=none


### PR DESCRIPTION
## Problem

- App is level 2

## Solution

- Enable upgrade test, required for level 3 and beyond

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
