### PR TITLE
Only allow $app and www-data to read $final_path folder

### DIFF
--- a/check_process
+++ b/check_process
@@ -15,11 +15,11 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1	from_commit=928272bb6c3f68173d1f1fe8b11e48e3464c730e
+		upgrade=1	from_commit=38c46ddf46c1d42fe4184924cfcfc890fa3014d4
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
 		change_url=1
 ;;; Upgrade options
-	; commit=928272bb6c3f68173d1f1fe8b11e48e3464c730e
+	; commit=38c46ddf46c1d42fe4184924cfcfc890fa3014d4
 		manifest_arg=domain=DOMAIN&path=PATH&language=fr&is_public=1&q2a_name=ATestQ2ASite&admin=USER&password=password&

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Platform for Question&Answer sites.",
         "fr": "Plateforme de Question/Réponses."
     },
-    "version": "1.8.5~ynh2",
+    "version": "1.8.5~ynh3",
     "url": "https://www.question2answer.org/",
     "license": "GPL-2.0-or-later",
     "maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -247,8 +247,11 @@ ynh_store_file_checksum --file="$final_path/.htaccess"
 # Set permissions to app files
 chown -R root: $final_path
 
+chmod o-rwx $final_path
+chown $app:www-data $final_path
+
 # Remove database initialization file
-#rm $final_path/qa-include/qa-install.php
+rm $final_path/qa-include/qa-install.php
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,6 +75,9 @@ ynh_system_user_create --username=$app
 # Restore permissions on app files
 chown -R root: $final_path
 
+chmod o-rwx $final_path
+chown $app:www-data $final_path
+
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -153,6 +153,9 @@ fi
 # Set permissions on app files
 chown -R root: $final_path
 
+chmod o-rwx $final_path
+chown $app:www-data $final_path
+
 #=================================================
 # RELOAD NGINX
 #=================================================


### PR DESCRIPTION
## Problem
- The $final_path folder is readable by almost any user, secrets included

## Solution
- Only allow the $app user (from php-fpm) and the www-data user (from nginx) to access that folder

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
